### PR TITLE
add support for atomic-traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,4 @@ default = ["atomic_f64"]
 atomic_f64 = []
 
 [dependencies]
+atomic-traits = { version = "0.3.0", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,9 @@
 mod atomic_f32;
 pub use atomic_f32::AtomicF32;
 
+#[cfg(feature = "atomic-traits")]
+mod traits_f32;
+
 #[cfg(all(
     feature = "atomic_f64",
     not(any(target_arch = "powerpc", target_arch = "mips", force_disable_atomic64))
@@ -92,6 +95,13 @@ mod atomic_f64;
     not(any(target_arch = "powerpc", target_arch = "mips", force_disable_atomic64))
 ))]
 pub use atomic_f64::AtomicF64;
+
+#[cfg(all(
+    feature = "atomic_f64",
+    feature = "atomic-traits",
+    not(any(target_arch = "powerpc", target_arch = "mips", force_disable_atomic64))
+))]
+mod traits_f64;
 
 use core::sync::atomic::Ordering;
 

--- a/src/traits_f32.rs
+++ b/src/traits_f32.rs
@@ -1,0 +1,152 @@
+use core::sync::atomic::Ordering;
+
+use atomic_traits::{
+    //fetch::{And, Nand, Or, Xor},
+    //Bitwise,
+    fetch::{Add, Max, Min, Sub, Update},
+    Atomic,
+    NumOps,
+};
+
+use crate::AtomicF32;
+
+impl Atomic for AtomicF32 {
+    type Type = f32;
+
+    fn new(v: Self::Type) -> Self {
+        Self::new(v)
+    }
+
+    fn get_mut(&mut self) -> &mut Self::Type {
+        Self::get_mut(self)
+    }
+
+    fn into_inner(self) -> Self::Type {
+        Self::into_inner(self)
+    }
+
+    fn load(&self, order: Ordering) -> Self::Type {
+        Self::load(&self, order)
+    }
+
+    fn store(&self, val: Self::Type, order: Ordering) {
+        Self::store(&self, val, order)
+    }
+
+    fn swap(&self, val: Self::Type, order: Ordering) -> Self::Type {
+        Self::swap(&self, val, order)
+    }
+
+    fn compare_and_swap(
+        &self,
+        current: Self::Type,
+        new: Self::Type,
+        order: Ordering,
+    ) -> Self::Type {
+        Self::compare_and_swap(&self, current, new, order)
+    }
+
+    fn compare_exchange(
+        &self,
+        current: Self::Type,
+        new: Self::Type,
+        success: Ordering,
+        failure: Ordering,
+    ) -> Result<Self::Type, Self::Type> {
+        Self::compare_exchange(&self, current, new, success, failure)
+    }
+
+    fn compare_exchange_weak(
+        &self,
+        current: Self::Type,
+        new: Self::Type,
+        success: Ordering,
+        failure: Ordering,
+    ) -> Result<Self::Type, Self::Type> {
+        Self::compare_exchange_weak(&self, current, new, success, failure)
+    }
+}
+
+impl Add for AtomicF32 {
+    type Type = f32;
+
+    fn fetch_add(&self, val: Self::Type, order: Ordering) -> Self::Type {
+        Self::fetch_add(&self, val, order)
+    }
+}
+
+//impl And for AtomicF32 {
+//    type Type = f32;
+//
+//    fn fetch_and(&self, val: Self::Type, order: Ordering) -> Self::Type {
+//        Self::fetch_and(&self, val, order)
+//    }
+//}
+
+impl Max for AtomicF32 {
+    type Type = f32;
+
+    fn fetch_max(&self, val: Self::Type, order: Ordering) -> Self::Type {
+        Self::fetch_max(&self, val, order)
+    }
+}
+
+impl Min for AtomicF32 {
+    type Type = f32;
+
+    fn fetch_min(&self, val: Self::Type, order: Ordering) -> Self::Type {
+        Self::fetch_min(&self, val, order)
+    }
+}
+
+//impl Nand for AtomicF32 {
+//    type Type = f32;
+//
+//    fn fetch_nand(&self, val: Self::Type, order: Ordering) -> Self::Type {
+//        Self::fetch_nand(&self, val, order)
+//    }
+//}
+
+//impl Or for AtomicF32 {
+//    type Type = f32;
+//
+//    fn fetch_or(&self, val: Self::Type, order: Ordering) -> Self::Type {
+//        Self::fetch_or(&self, val, order)
+//    }
+//}
+
+impl Sub for AtomicF32 {
+    type Type = f32;
+
+    fn fetch_sub(&self, val: Self::Type, order: Ordering) -> Self::Type {
+        Self::fetch_sub(&self, val, order)
+    }
+}
+
+impl Update for AtomicF32 {
+    type Type = f32;
+
+    fn fetch_update<F>(
+        &self,
+        fetch_order: Ordering,
+        set_order: Ordering,
+        f: F,
+    ) -> Result<Self::Type, Self::Type>
+    where
+        F: FnMut(Self::Type) -> Option<Self::Type>,
+    {
+        Self::fetch_update(&self, fetch_order, set_order, f)
+    }
+}
+
+//impl Xor for AtomicF32 {
+//    type Type = f32;
+//
+//    fn fetch_xor(&self, val: Self::Type, order: Ordering) -> Self::Type {
+//        Self::fetch_xor(&self, val, order)
+//    }
+//}
+
+//impl Bitwise for AtomicF32 {}
+
+impl NumOps for AtomicF32 {}

--- a/src/traits_f64.rs
+++ b/src/traits_f64.rs
@@ -1,0 +1,152 @@
+use core::sync::atomic::Ordering;
+
+use atomic_traits::{
+    //fetch::{And, Nand, Or, Xor},
+    //Bitwise,
+    fetch::{Add, Max, Min, Sub, Update},
+    Atomic,
+    NumOps,
+};
+
+use crate::AtomicF64;
+
+impl Atomic for AtomicF64 {
+    type Type = f64;
+
+    fn new(v: Self::Type) -> Self {
+        Self::new(v)
+    }
+
+    fn get_mut(&mut self) -> &mut Self::Type {
+        Self::get_mut(self)
+    }
+
+    fn into_inner(self) -> Self::Type {
+        Self::into_inner(self)
+    }
+
+    fn load(&self, order: Ordering) -> Self::Type {
+        Self::load(&self, order)
+    }
+
+    fn store(&self, val: Self::Type, order: Ordering) {
+        Self::store(&self, val, order)
+    }
+
+    fn swap(&self, val: Self::Type, order: Ordering) -> Self::Type {
+        Self::swap(&self, val, order)
+    }
+
+    fn compare_and_swap(
+        &self,
+        current: Self::Type,
+        new: Self::Type,
+        order: Ordering,
+    ) -> Self::Type {
+        Self::compare_and_swap(&self, current, new, order)
+    }
+
+    fn compare_exchange(
+        &self,
+        current: Self::Type,
+        new: Self::Type,
+        success: Ordering,
+        failure: Ordering,
+    ) -> Result<Self::Type, Self::Type> {
+        Self::compare_exchange(&self, current, new, success, failure)
+    }
+
+    fn compare_exchange_weak(
+        &self,
+        current: Self::Type,
+        new: Self::Type,
+        success: Ordering,
+        failure: Ordering,
+    ) -> Result<Self::Type, Self::Type> {
+        Self::compare_exchange_weak(&self, current, new, success, failure)
+    }
+}
+
+impl Add for AtomicF64 {
+    type Type = f64;
+
+    fn fetch_add(&self, val: Self::Type, order: Ordering) -> Self::Type {
+        Self::fetch_add(&self, val, order)
+    }
+}
+
+//impl And for AtomicF64 {
+//    type Type = f64;
+//
+//    fn fetch_and(&self, val: Self::Type, order: Ordering) -> Self::Type {
+//        Self::fetch_and(&self, val, order)
+//    }
+//}
+
+impl Max for AtomicF64 {
+    type Type = f64;
+
+    fn fetch_max(&self, val: Self::Type, order: Ordering) -> Self::Type {
+        Self::fetch_max(&self, val, order)
+    }
+}
+
+impl Min for AtomicF64 {
+    type Type = f64;
+
+    fn fetch_min(&self, val: Self::Type, order: Ordering) -> Self::Type {
+        Self::fetch_min(&self, val, order)
+    }
+}
+
+//impl Nand for AtomicF64 {
+//    type Type = f64;
+//
+//    fn fetch_nand(&self, val: Self::Type, order: Ordering) -> Self::Type {
+//        Self::fetch_nand(&self, val, order)
+//    }
+//}
+
+//impl Or for AtomicF64 {
+//    type Type = f64;
+//
+//    fn fetch_or(&self, val: Self::Type, order: Ordering) -> Self::Type {
+//        Self::fetch_or(&self, val, order)
+//    }
+//}
+
+impl Sub for AtomicF64 {
+    type Type = f64;
+
+    fn fetch_sub(&self, val: Self::Type, order: Ordering) -> Self::Type {
+        Self::fetch_sub(&self, val, order)
+    }
+}
+
+impl Update for AtomicF64 {
+    type Type = f64;
+
+    fn fetch_update<F>(
+        &self,
+        fetch_order: Ordering,
+        set_order: Ordering,
+        f: F,
+    ) -> Result<Self::Type, Self::Type>
+    where
+        F: FnMut(Self::Type) -> Option<Self::Type>,
+    {
+        Self::fetch_update(&self, fetch_order, set_order, f)
+    }
+}
+
+//impl Xor for AtomicF64 {
+//    type Type = f64;
+//
+//    fn fetch_xor(&self, val: Self::Type, order: Ordering) -> Self::Type {
+//        Self::fetch_xor(&self, val, order)
+//    }
+//}
+
+//impl Bitwise for AtomicF64 {}
+
+impl NumOps for AtomicF64 {}


### PR DESCRIPTION
There are some other traits exposed by the [`atomic-traits`](https://docs.rs/atomic-traits) crate that require methods that aren't already implemented and I opted to leave them unimplemented (for now?). The wrapper code to make those traits work is just commented out in the event I or someone else adds the actual implementations later, but if having comments hanging around in the codebase is undesirable I could get rid of them.