### PR TITLE
Support serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,4 @@ default = ["atomic_f64"]
 atomic_f64 = []
 
 [dependencies]
+serde = { version = "1", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,4 @@ default = ["atomic_f64"]
 atomic_f64 = []
 
 [dependencies]
-serde = { version = "1", optional = true }
+serde = { version = "1", optional = true, default-features = false }

--- a/src/atomic_f32.rs
+++ b/src/atomic_f32.rs
@@ -744,3 +744,33 @@ impl From<f32> for AtomicF32 {
         Self::new(f)
     }
 }
+
+#[cfg(feature = "serde")]
+/// Serializes the AtomicF32
+///
+/// The value is loaded with the `Ordering::SeqCst` and then serializes
+/// it as a normal `f32`. The information about the object being atomic is lost.
+impl serde::Serialize for AtomicF32 {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_f32(self.load(Ordering::SeqCst))
+    }
+}
+
+#[cfg(feature = "serde")]
+/// Deserializes the AtomicF32
+///
+/// Attempts to deserialize f32 and, if successful, creates a new
+/// AtomicF32 with this value.
+impl<'de> serde::Deserialize<'de> for AtomicF32 {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = f32::deserialize(deserializer)?;
+
+        Ok(AtomicF32::new(value))
+    }
+}

--- a/src/atomic_f64.rs
+++ b/src/atomic_f64.rs
@@ -750,3 +750,33 @@ impl From<f64> for AtomicF64 {
         Self::new(f)
     }
 }
+
+#[cfg(feature = "serde")]
+/// Serializes the AtomicF64
+///
+/// The value is loaded with the `Ordering::SeqCst` and then serializes
+/// it as a normal `f64`. The information about the object being atomic is lost.
+impl serde::Serialize for AtomicF64 {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_f64(self.load(Ordering::SeqCst))
+    }
+}
+
+#[cfg(feature = "serde")]
+/// Deserializes the AtomicF64
+///
+/// Attempts to deserialize f64 and, if successful, creates a new
+/// AtomicF64 with this value.
+impl<'de> serde::Deserialize<'de> for AtomicF64 {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = f64::deserialize(deserializer)?;
+
+        Ok(AtomicF64::new(value))
+    }
+}


### PR DESCRIPTION
The serde dependency and `Serialize` / `Deserialize` trait impls are behind the `serde` feature flag.