### PR TITLE
Various improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,6 @@ atomic_f64 = []
 
 [dependencies]
 serde = { version = "1", optional = true, default-features = false }
+
+[dev-dependencies]
+serde_test = { version = "1", default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,6 +101,6 @@ fn fail_order_for(order: Ordering) -> Ordering {
         Ordering::Release | Ordering::Relaxed => Ordering::Relaxed,
         Ordering::Acquire | Ordering::AcqRel => Ordering::Acquire,
         Ordering::SeqCst => Ordering::SeqCst,
-        o => o,
+        o => unreachable!("Unknown ordering: {:?} (file a bug with atomic_float)", o),
     }
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -16,3 +16,21 @@ fn readme_test() {
 
     assert_eq!(A_STATIC.load(Relaxed), -885.0);
 }
+
+#[cfg(feature = "serde")]
+#[test]
+fn test_serde_f32() {
+    serde_test::assert_tokens(
+        &atomic_float::AtomicF32::new(1.0),
+        &[serde_test::Token::F32(1.0)],
+    );
+}
+
+#[cfg(all(feature = "serde", feature = "atomic_f64"))]
+#[test]
+fn test_serde_f64() {
+    serde_test::assert_tokens(
+        &atomic_float::AtomicF64::new(1.0),
+        &[serde_test::Token::F64(1.0)],
+    );
+}


### PR DESCRIPTION
Add serde tests, and implement PartialEq for AtomicF{64,32}, improve coverage.

Current coverage is 100% now[^1] (although the CI is currently broken, so it won't update).

[^1]: A bit obsessive admittedly, but this is the kinda crate where a copypaste error would be super easy to make, and really hard for a user to debug.

```
$ cargo tarpaulin --doc --all-targets --all-features
<snip: blah blah blah>
|| Uncovered Lines:
|| Tested/Total Lines:
|| src/atomic_f32.rs: 68/68 +0.00%
|| src/atomic_f64.rs: 70/70 +0.00%
|| src/lib.rs: 5/5 +0.00%
||
100.00% coverage, 143/143 lines covered, +0.00% change in coverage
```