### PR TITLE
Only use target_has_atomic instead of the atomic_f64 feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,12 +29,7 @@ jobs:
       - uses: hecrj/setup-rust-action@v2
         with:
           rust-version: ${{ matrix.rust }}
-      - run: cargo test --verbose --workspace --all-features
-      - run: cargo test --verbose --workspace --no-default-features
-      - run: cargo test --verbose --workspace --all-features
-        env:
-          RUSTFLAGS: "--cfg force_disable_atomic64"
-          RUSTDOCFLAGS: "--cfg force_disable_atomic64"
+      - run: cargo test --verbose --workspace
 
   cross-test:
     name: Test on ${{ matrix.target }} (using cross)
@@ -52,8 +47,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: hecrj/setup-rust-action@v2
       - run: cargo install cross
-      - run: cross test --verbose --target=${{ matrix.target }} --no-default-features
-      - run: cross test --verbose --target=${{ matrix.target }} --all-features
+      - run: cross test --verbose --target=${{ matrix.target }}
 
   check:
     name: Check warnings
@@ -64,7 +58,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: hecrj/setup-rust-action@v2
       - run: cargo check --workspace --all-targets --verbose
-      - run: cargo check --workspace --all-targets --verbose --no-default-features
 
   rustfmt:
     name: Verify code formatting

--- a/src/atomic_f64.rs
+++ b/src/atomic_f64.rs
@@ -12,7 +12,7 @@ use core::sync::atomic::{
 /// See the module documentation for [core::sync::atomic] for information about
 /// the portability of various atomics (this one is mostly as portable as
 /// [`AtomicU64`](core::sync::atomic::AtomicU64), with the caveat that we
-/// additionally that the platform support 64-bit floats).
+/// additionally require that the platform support 64-bit floats).
 ///
 /// # Example
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,20 +24,9 @@
 //! [`AtomicU32`]: core::sync::atomic::AtomicU32
 //! [`AtomicU64`]: core::sync::atomic::AtomicU64
 //!
-//! Not every architecture has 64-bit atomics. As a result [`AtomicF64`] is
-//! behind an on-by-default feature flag, called `atomic_f64`, and is explicitly
-//! disabled on platforms known not to have 64-bit atomics (32-bit MIPs and
-//! PowerPC targets).
-//!
-//! Because it's on-by-default, it's possible it will be enabled by accident. If
-//! you're the person compiling the end-result (invoking `cargo build`), and
-//! some crate has done this (e.g. you can't simply add
-//! `default-features=false`) to a `Cargo.toml` line, you can override feature
-//! selection and force-disable `AtomicF64` using the `force_disable_atomic64`
-//! cfg (that is, by adding `RUSTFLAGS="--cfg=force_disable_atomic64"`).
-//!
-//! Let me know if you have to do this though, and I'll make consideration for
-//! your target the way I have for MIPs and PowerPC.
+//! Some architectures do not support 64-bit atomics, so [`AtomicF64`] is not
+//! available on such architectures. Examples include 32-bit PowerPC, MIPS, and
+//! Arm M-Profile.
 //!
 //! # Potential Use Cases
 //!
@@ -81,18 +70,10 @@
 mod atomic_f32;
 pub use atomic_f32::AtomicF32;
 
-#[cfg(all(
-    feature = "atomic_f64",
-    target_has_atomic = "64",
-    not(force_disable_atomic64),
-))]
+#[cfg(target_has_atomic = "64")]
 mod atomic_f64;
 
-#[cfg(all(
-    feature = "atomic_f64",
-    target_has_atomic = "64",
-    not(force_disable_atomic64),
-))]
+#[cfg(target_has_atomic = "64")]
 pub use atomic_f64::AtomicF64;
 
 use core::sync::atomic::Ordering;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -26,12 +26,7 @@ fn test_serde_f32() {
     );
 }
 
-#[cfg(all(
-    feature = "serde",
-    feature = "atomic_f64",
-    target_has_atomic = "64",
-    not(force_disable_atomic64),
-))]
+#[cfg(all(feature = "serde", target_has_atomic = "64"))]
 #[test]
 fn test_serde_f64() {
     serde_test::assert_tokens(


### PR DESCRIPTION
Fixes #13.
