### PR TITLE
Add atomic-traits 0.4 support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ atomic_f64 = []
 
 [dependencies]
 serde = { version = "1", optional = true, default-features = false }
-atomic-traits = { version = "0.3", optional = true }
+atomic-traits = { version = "0.4", optional = true }
 
 [dev-dependencies]
 serde_test = { version = "1", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ homepage = "https://github.com/thomcc/atomic_float"
 [features]
 default = ["atomic_f64"]
 atomic_f64 = []
+serde = ["dep:serde"]
 
 [dependencies]
 serde = { version = "1", optional = true, default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,10 @@ homepage = "https://github.com/thomcc/atomic_float"
 [features]
 default = ["atomic_f64"]
 atomic_f64 = []
-serde = ["dep:serde"]
 
 [dependencies]
 serde = { version = "1", optional = true, default-features = false }
+atomic-traits = { version = "0.3", optional = true }
 
 [dev-dependencies]
 serde_test = { version = "1", default-features = false }

--- a/src/atomic_f32.rs
+++ b/src/atomic_f32.rs
@@ -817,3 +817,60 @@ impl PartialEq for AtomicF32 {
         self.load(Relaxed) == o.load(Relaxed)
     }
 }
+#[cfg(feature = "atomic-traits")]
+impl atomic_traits::Atomic for AtomicF32 {
+    type Type = f32;
+
+    fn new(v: Self::Type) -> Self {
+        Self::new(v)
+    }
+
+    fn get_mut(&mut self) -> &mut Self::Type {
+        self.get_mut()
+    }
+
+    fn into_inner(self) -> Self::Type {
+        self.into_inner()
+    }
+
+    fn load(&self, order: Ordering) -> Self::Type {
+        self.load(order)
+    }
+
+    fn store(&self, val: Self::Type, order: Ordering) {
+        self.store(val, order)
+    }
+
+    fn swap(&self, val: Self::Type, order: Ordering) -> Self::Type {
+        self.swap(val, order)
+    }
+
+    fn compare_and_swap(
+        &self,
+        current: Self::Type,
+        new: Self::Type,
+        order: Ordering,
+    ) -> Self::Type {
+        self.compare_and_swap(current, new, order)
+    }
+
+    fn compare_exchange(
+        &self,
+        current: Self::Type,
+        new: Self::Type,
+        success: Ordering,
+        failure: Ordering,
+    ) -> Result<Self::Type, Self::Type> {
+        self.compare_exchange(current, new, success, failure)
+    }
+
+    fn compare_exchange_weak(
+        &self,
+        current: Self::Type,
+        new: Self::Type,
+        success: Ordering,
+        failure: Ordering,
+    ) -> Result<Self::Type, Self::Type> {
+        self.compare_exchange_weak(current, new, success, failure)
+    }
+}

--- a/src/atomic_f64.rs
+++ b/src/atomic_f64.rs
@@ -811,3 +811,60 @@ impl PartialEq for AtomicF64 {
         self.load(Relaxed) == o.load(Relaxed)
     }
 }
+#[cfg(feature = "atomic-traits")]
+impl atomic_traits::Atomic for AtomicF64 {
+    type Type = f64;
+
+    fn new(v: Self::Type) -> Self {
+        Self::new(v)
+    }
+
+    fn get_mut(&mut self) -> &mut Self::Type {
+        self.get_mut()
+    }
+
+    fn into_inner(self) -> Self::Type {
+        self.into_inner()
+    }
+
+    fn load(&self, order: Ordering) -> Self::Type {
+        self.load(order)
+    }
+
+    fn store(&self, val: Self::Type, order: Ordering) {
+        self.store(val, order)
+    }
+
+    fn swap(&self, val: Self::Type, order: Ordering) -> Self::Type {
+        self.swap(val, order)
+    }
+
+    fn compare_and_swap(
+        &self,
+        current: Self::Type,
+        new: Self::Type,
+        order: Ordering,
+    ) -> Self::Type {
+        self.compare_and_swap(current, new, order)
+    }
+
+    fn compare_exchange(
+        &self,
+        current: Self::Type,
+        new: Self::Type,
+        success: Ordering,
+        failure: Ordering,
+    ) -> Result<Self::Type, Self::Type> {
+        self.compare_exchange(current, new, success, failure)
+    }
+
+    fn compare_exchange_weak(
+        &self,
+        current: Self::Type,
+        new: Self::Type,
+        success: Ordering,
+        failure: Ordering,
+    ) -> Result<Self::Type, Self::Type> {
+        self.compare_exchange_weak(current, new, success, failure)
+    }
+}


### PR DESCRIPTION
This PR adds support for atomic-traits 0.4

There is already a [PR by CobaltCause](https://github.com/thomcc/atomic_float/pull/4) adding support for atomic_traits, but that's for atomic_traits 0.3, and has a bunch of merge conflicts, so I just created a new PR.